### PR TITLE
fix: WebAssembly Compilation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,31 @@
 use std::env;
 use std::path::PathBuf;
 
+const EM_OS: &str = "emscripten";
+
 fn main() {
     // Tell cargo to invalidate the built crate whenever the sources change
     println!("cargo:rerun-if-changed=flecs.h");
     println!("cargo:rerun-if-changed=flecs.c");
 
+    // Grab this value because #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] does not work in build.rs
+    // because it assumes that the target is the default OS target
+    // when you specify wasm32-unknown-emscripten.
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap().to_string();
+    if target_os == EM_OS {
+      // Export as JS file as ES6 Module by adding emscripten flag
+      println!("cargo:rustc-link-arg=-sEXPORT_ES6=1");
+      println!("cargo:rustc-link-arg=-sMODULARIZE=1");
+    }
+
     let bindings = bindgen::Builder::default()
         // The input header we would like to generate
         // bindings for.
         .header("flecs.h")
-		.generate_comments(false)
-		.layout_tests(false)
+        // Nessecary for Emscripten target.
+        .clang_arg("-fvisibility=default")
+        .generate_comments(false)
+        .layout_tests(false)
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
@@ -27,7 +41,7 @@ fn main() {
         .expect("Couldn't write bindings!");
 
     // Compile flecs C right into our Rust crate
-	cc::Build::new()
-		.file("flecs.c")
-		.compile("flecs");		
+    cc::Build::new()
+      .file("flecs.c")
+      .compile("flecs");		
 }

--- a/readme.md
+++ b/readme.md
@@ -75,12 +75,12 @@ cargo run --example hello_world
 cargo run --example prefabs
 ```
 
-## Usage with WebAssembly
-Usage with WebAssembly requires using the `wasm32-unknown-emscripten`.
+## Compiling with WebAssembly
+Compiling with WebAssembly requires using the `wasm32-unknown-emscripten` target.
 
-This is because there is no official toolchain for C/C++ targeting wasm32-unknown-unknown, which means C/C++ bindings do not work and will result in unresolved symbols.
+This is because there is no official toolchain for C/C++ targeting `wasm32-unknown-unknown`, which means that C/C++ bindings with do not work with this target and will result in unresolved symbols.
 
-This target which is not as well supported as the `wasm32-unknown-unknown` which means `wasm-bindgen` and some other popular Rust libraries that target WebAssembly will not work. So be sure to keep that in mind.
+The Emscripten target which is not as well supported as the `wasm32-unknown-unknown`, which means that `wasm-bindgen` and some other popular Rust libraries that target WebAssembly will not work. So be sure to keep that in mind.
 
 Create a directory to be statically served:
 ```bash

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ Create a directory to be statically served:
 mkdir static
 ```
 
-Create a file called `index.html` unders `static/`:
+Create a file called `index.html` under `static/`:
 ```html
 <html>
   <body>

--- a/readme.md
+++ b/readme.md
@@ -74,3 +74,40 @@ cargo test
 cargo run --example hello_world
 cargo run --example prefabs
 ```
+
+## Usage with WebAssembly
+Usage with WebAssembly requires using the `wasm32-unknown-emscripten`.
+
+This is because there is no official toolchain for C/C++ targeting wasm32-unknown-unknown, which means C/C++ bindings do not work and will result in unresolved symbols.
+
+This target which is not as well supported as the `wasm32-unknown-unknown` which means `wasm-bindgen` and some other popular Rust libraries that target WebAssembly will not work. So be sure to keep that in mind.
+
+Create a directory to be statically served:
+```bash
+mkdir static
+```
+
+Create a file called `index.html` unders `static/`:
+```html
+<html>
+  <body>
+    <script type="module">
+      import init from './systems.js'
+      await init()
+    </script>
+  </body>
+</html>
+```
+
+Build WASM binary:
+```bash
+build --example systems --target wasm32-unknown-emscripten
+cp ./target/wasm32-unknown-emscripten/debug/examples/systems.js ./static/
+cp ./target/wasm32-unknown-emscripten/debug/examples/systems.wasm ./static/
+```
+
+Serve static file locally with any HTTP server tool, for example `basic-http-server`:
+```bash
+cargo install basic-http-server
+basic-http-server ./static/
+```

--- a/src/component.rs
+++ b/src/component.rs
@@ -115,8 +115,14 @@ pub fn register_component(world: *mut ecs_world_t, desc: ComponentDescriptor) ->
 	let comp_desc = ecs_component_desc_t {
         _canary: 0,
 		entity: e_desc,
-		size: desc.layout.size() as u64,
-		alignment: desc.layout.align() as u64,
+    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
+    size: desc.layout.size() as u32,
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
+    size: desc.layout.size() as u64,
+    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
+		alignment: desc.layout.align() as u32,
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
+		alignment: desc.layout.align() as u32,
 	};
 
 	let comp_entity = unsafe { ecs_component_init(world, &comp_desc) };

--- a/src/component.rs
+++ b/src/component.rs
@@ -113,17 +113,18 @@ pub fn register_component(world: *mut ecs_world_t, desc: ComponentDescriptor) ->
 	
 	// let s_id = 0;
 	let comp_desc = ecs_component_desc_t {
-        _canary: 0,
+		_canary: 0,
 		entity: e_desc,
-    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
-    size: desc.layout.size() as u32,
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
-    size: desc.layout.size() as u64,
-    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
+		#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
+		size: desc.layout.size() as u32,
+		#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
+		size: desc.layout.size() as u64,
+		#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
 		alignment: desc.layout.align() as u32,
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
+		#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
 		alignment: desc.layout.align() as u64,
 	};
+
 
 	let comp_entity = unsafe { ecs_component_init(world, &comp_desc) };
 	// println!("register_component - comp_entity {}", comp_entity);

--- a/src/component.rs
+++ b/src/component.rs
@@ -122,7 +122,7 @@ pub fn register_component(world: *mut ecs_world_t, desc: ComponentDescriptor) ->
     #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
 		alignment: desc.layout.align() as u32,
     #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
-		alignment: desc.layout.align() as u32,
+		alignment: desc.layout.align() as u64,
 	};
 
 	let comp_entity = unsafe { ecs_component_init(world, &comp_desc) };

--- a/src/component.rs
+++ b/src/component.rs
@@ -115,14 +115,8 @@ pub fn register_component(world: *mut ecs_world_t, desc: ComponentDescriptor) ->
 	let comp_desc = ecs_component_desc_t {
 		_canary: 0,
 		entity: e_desc,
-		#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
-		size: desc.layout.size() as u32,
-		#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
-		size: desc.layout.size() as u64,
-		#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
-		alignment: desc.layout.align() as u32,
-		#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
-		alignment: desc.layout.align() as u64,
+		size: desc.layout.size() as size_t,
+		alignment: desc.layout.align() as size_t,
 	};
 
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -280,65 +280,65 @@ impl Iter {
     }
 
     fn get_term<T: Component>(&self, index: i32) -> Column<T> {
-		// validate that types match. could avoid this in Release builds perhaps to get max perf
-        let term_id = unsafe { ecs_term_id(self.it, index) };
-		let world = unsafe { (*self.it).real_world };	// must use real to get component infos
-		let comp_id = WorldInfoCache::get_component_id_for_type::<T>(world).expect("Component type not registered!");
-		// println!("Term: {}, Comp: {}", term_id, comp_id);
-		assert!(term_id == comp_id);
+			// validate that types match. could avoid this in Release builds perhaps to get max perf
+			let term_id = unsafe { ecs_term_id(self.it, index) };
+			let world = unsafe { (*self.it).real_world };	// must use real to get component infos
+			let comp_id = WorldInfoCache::get_component_id_for_type::<T>(world).expect("Component type not registered!");
+			// println!("Term: {}, Comp: {}", term_id, comp_id);
+			assert!(term_id == comp_id);
 
-		/* TODO - validate that the types actually match!!!!
-#ifndef NDEBUG
-        ecs_assert(term_id & ECS_PAIR || term_id & ECS_SWITCH || 
-            term_id & ECS_CASE ||
-            term_id == _::cpp_type<T>::id(m_iter->world), 
-            ECS_COLUMN_TYPE_MISMATCH, NULL);
-#endif
-		*/
+			/* TODO - validate that the types actually match!!!!
+	#ifndef NDEBUG
+					ecs_assert(term_id & ECS_PAIR || term_id & ECS_SWITCH || 
+							term_id & ECS_CASE ||
+							term_id == _::cpp_type<T>::id(m_iter->world), 
+							ECS_COLUMN_TYPE_MISMATCH, NULL);
+	#endif
+			*/
 
-        let mut count = self.count();
+			let mut count = self.count();
 
-        let is_shared = unsafe { !ecs_term_is_owned2(self.it, index) };
+			let is_shared = unsafe { !ecs_term_is_owned2(self.it, index) };
 
-        /* If a shared column is retrieved with 'column', there will only be a
-         * single value. Ensure that the application does not accidentally read
-         * out of bounds. */
-        if is_shared {
-            count = 1;
-        }
-		// println!("Term: {}, is_shared: {}, count: {}", term_id, is_shared, count);
+			/* If a shared column is retrieved with 'column', there will only be a
+				* single value. Ensure that the application does not accidentally read
+				* out of bounds. */
+			if is_shared {
+					count = 1;
+			}
+			// println!("Term: {}, is_shared: {}, count: {}", term_id, is_shared, count);
 
-    let size = std::mem::size_of::<T>();
-    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
-    let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut T };
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
-    let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut T };
-        
-		Column::new(array, count, is_shared)
+			let size = std::mem::size_of::<T>();
+			#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
+			let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut T };
+			#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
+			let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut T };
+
+			Column::new(array, count, is_shared)
     }
 
     pub fn get_term_dynamic(&self, index: i32) -> ColumnDynamic {
-        let mut count = self.count();
-        let is_shared = unsafe { !ecs_term_is_owned2(self.it, index) };
-        if is_shared {
-            count = 1;
-        }
+			let mut count = self.count();
+			let is_shared = unsafe { !ecs_term_is_owned2(self.it, index) };
+			if is_shared {
+				count = 1;
+			}
 
-		// TODO: look this up within the component info
-		let world = unsafe { (*self.it).real_world };
-        let term_id = unsafe { ecs_term_id(self.it, index) };
-		
-		let mut size = 0;	// we only get a size if there is a component?
-		if let Some(info) = get_component_info(world, term_id) {
+			// TODO: look this up within the component info
+			let world = unsafe { (*self.it).real_world };
+				let term_id = unsafe { ecs_term_id(self.it, index) };
+
+			let mut size = 0;	// we only get a size if there is a component?
+			if let Some(info) = get_component_info(world, term_id) {
 			size = info.size;
-		}
+			}
 
-    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
-    let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut u8 };
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
-    let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut u8 };
-    
-		ColumnDynamic::new(array, count, size as usize, is_shared)
+			#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
+			let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut u8 };
+			#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
+			let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut u8 };
+
+			ColumnDynamic::new(array, count, size as usize, is_shared)
     }	
 }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -309,6 +309,9 @@ impl Iter {
 		// println!("Term: {}, is_shared: {}, count: {}", term_id, is_shared, count);
 
 		let size = std::mem::size_of::<T>();
+    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
+    let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut T };
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
 		let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut T };
         
 		Column::new(array, count, is_shared)
@@ -330,7 +333,11 @@ impl Iter {
 			size = info.size;
 		}
 
+    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
+		let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut u8 };
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
 		let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut u8 };
+    
 		ColumnDynamic::new(array, count, size as usize, is_shared)
     }	
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -309,10 +309,7 @@ impl Iter {
 			// println!("Term: {}, is_shared: {}, count: {}", term_id, is_shared, count);
 
 			let size = std::mem::size_of::<T>();
-			#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
-			let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut T };
-			#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
-			let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut T };
+			let array = unsafe { ecs_term_w_size(self.it, size as size_t, index) as *mut T };
 
 			Column::new(array, count, is_shared)
     }
@@ -333,10 +330,7 @@ impl Iter {
 			size = info.size;
 			}
 
-			#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
-			let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut u8 };
-			#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
-			let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut u8 };
+			let array = unsafe { ecs_term_w_size(self.it, size as size_t, index) as *mut u8 };
 
 			ColumnDynamic::new(array, count, size as usize, is_shared)
     }	

--- a/src/system.rs
+++ b/src/system.rs
@@ -308,11 +308,11 @@ impl Iter {
         }
 		// println!("Term: {}, is_shared: {}, count: {}", term_id, is_shared, count);
 
-		let size = std::mem::size_of::<T>();
-    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
+    let size = std::mem::size_of::<T>();
+    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
     let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut T };
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
-		let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut T };
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
+    let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut T };
         
 		Column::new(array, count, is_shared)
     }
@@ -333,10 +333,10 @@ impl Iter {
 			size = info.size;
 		}
 
-    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))] 
-		let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut u8 };
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
-		let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut u8 };
+    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
+    let array = unsafe { ecs_term_w_size(self.it, size as u32, index) as *mut u8 };
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
+    let array = unsafe { ecs_term_w_size(self.it, size as u64, index) as *mut u8 };
     
 		ColumnDynamic::new(array, count, size as usize, is_shared)
     }	

--- a/src/world.rs
+++ b/src/world.rs
@@ -298,10 +298,7 @@ impl Drop for World {
 impl World {
 	pub fn enable_rest(&self) {
     let rest_comp_id = unsafe { FLECS__EEcsRest as u64 };
-		#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
-		let rest_comp_size = std::mem::size_of::<EcsRest>() as u32;
-		#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
-		let rest_comp_size = std::mem::size_of::<EcsRest>() as u64;
+		let rest_comp_size = std::mem::size_of::<EcsRest>() as size_t;
 		
 		let rest_data: EcsRest = unsafe { MaybeUninit::zeroed().assume_init() };
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -297,10 +297,10 @@ impl Drop for World {
 // Additional Add-ons support
 impl World {
 	pub fn enable_rest(&self) {
-		let rest_comp_id = unsafe { FLECS__EEcsRest as u64 };
+    let rest_comp_id = unsafe { FLECS__EEcsRest as u64 };
     #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
     let rest_comp_size = std::mem::size_of::<EcsRest>() as u32;
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
     let rest_comp_size = std::mem::size_of::<EcsRest>() as u64;
 		
 		let rest_data: EcsRest = unsafe { MaybeUninit::zeroed().assume_init() };

--- a/src/world.rs
+++ b/src/world.rs
@@ -298,7 +298,11 @@ impl Drop for World {
 impl World {
 	pub fn enable_rest(&self) {
 		let rest_comp_id = unsafe { FLECS__EEcsRest as u64 };
-		let rest_comp_size = std::mem::size_of::<EcsRest>() as u64;
+    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
+    let rest_comp_size = std::mem::size_of::<EcsRest>() as u32;
+    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))] 
+    let rest_comp_size = std::mem::size_of::<EcsRest>() as u64;
+		
 		let rest_data: EcsRest = unsafe { MaybeUninit::zeroed().assume_init() };
 
 		unsafe { 

--- a/src/world.rs
+++ b/src/world.rs
@@ -298,10 +298,10 @@ impl Drop for World {
 impl World {
 	pub fn enable_rest(&self) {
     let rest_comp_id = unsafe { FLECS__EEcsRest as u64 };
-    #[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
-    let rest_comp_size = std::mem::size_of::<EcsRest>() as u32;
-    #[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
-    let rest_comp_size = std::mem::size_of::<EcsRest>() as u64;
+		#[cfg(all(target_arch = "wasm32", target_os = "emscripten"))]
+		let rest_comp_size = std::mem::size_of::<EcsRest>() as u32;
+		#[cfg(all(not(target_arch = "wasm32"), not(target_os = "emscripten")))]
+		let rest_comp_size = std::mem::size_of::<EcsRest>() as u64;
 		
 		let rest_data: EcsRest = unsafe { MaybeUninit::zeroed().assume_init() };
 


### PR DESCRIPTION
Fixed several type errors when compiling to WebAssembly, added flags to `build.rs`, and added instructions to compile to WebAssembly.

For example:
```
error[E0308]: mismatched types
   --> src/component.rs:118:9
    |
118 |         size: desc.layout.size() as u64,
    |               ^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `u64`

error[E0308]: mismatched types
   --> src/component.rs:119:14
    |
119 |         alignment: desc.layout.align() as u64,
    |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `u32`, found `u64`

```

`systems.rs` example Chrome logs:
![image](https://user-images.githubusercontent.com/16667416/152793344-0db2c521-cd53-48b8-9b7b-edbb2658a419.png)