### PR TITLE
ci: Use stable Rust for build step.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt
       - name: Build
         run: cargo build --workspace --verbose
       - name: Run tests


### PR DESCRIPTION
This updates the checkout action to the current latest (v4) and uses another action to make sure that the version of Rust being used is the current stable version (rather than whatever GitHub last installed).