### PR TITLE
ci: Check cargo fmt.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    name: cargo fmt
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install stable toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          components: rustfmt
+
+      - name: cargo fmt
+        run: cargo fmt --all --check
+
   build:
     runs-on: ubuntu-latest
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -1,4 +1,4 @@
-use std::alloc::{Layout, handle_alloc_error};
+use std::alloc::{handle_alloc_error, Layout};
 use std::ffi::c_void;
 use std::slice::from_raw_parts;
 
@@ -85,7 +85,7 @@ impl<'w> SystemBuilder<'w> {
 		}
 	}
 
-	pub fn context<T>(mut self, value:T) -> Self {
+	pub fn context<T>(mut self, value: T) -> Self {
 		assert!(!self.set_context);
 		let layout = Layout::new::<T>();
 		unsafe {
@@ -324,9 +324,7 @@ impl Iter {
 	}
 
 	pub unsafe fn get_context<'a, T>(&'a self) -> &'a T {
-		let context = (*self.it).ctx.cast::<T>()
-			.as_ref()
-			.unwrap();
+		let context = (*self.it).ctx.cast::<T>().as_ref().unwrap();
 		&context
 	}
 


### PR DESCRIPTION
Add a CI step for checking formatting against current stable Rust. Also, fix a couple of minor formatting issues by running `cargo fmt`.